### PR TITLE
Fix for the Remote Code Execution (RCE) Vulnerability

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -2,6 +2,7 @@ import { execSync, exec as _exec } from 'child_process';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as fs from 'fs';
+import * as isGitUrl from 'is-git-url';
 
 import mkdirp from './wrappers/mkdirp'
 import rimraf from './wrappers/rimraf';
@@ -58,6 +59,11 @@ export function publish(packageDir: string,
     tagMessageText?: string,
     tempDir?: string,
     packageInfo?: PackageInfo): Promise<boolean | Result> {
+
+    if (!isGitUrl(gitRemoteUrl)) {
+        console.log('\nERROR: The given Git Repo URL is not valid\n');
+        return;
+    }
 
     if (typeof options === 'string') {
         // using the deprecated overload

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typings": "^0.6.5"
   },
   "dependencies": {
+    "is-git-url": "^1.0.0",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "read-pkg": "^1.1.0",


### PR DESCRIPTION
This fix validates the given input for the '_gitRemoteUrl_' parameter value and validates whether it's a git repo URL or not. So the command will only execute when the input is a valid Git Repo URL.

As this application can run on different OS platforms (_Bash Terminals, Windows Terminal etc_), character escaping is a hassle and there will be ways to bypass it so I implemented Git Repo URL validation with **[is-git-url](https://www.npmjs.com/package/is-git-url)**. :)

**Fixed!** :+1: 